### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/irfan0032/f5c260a2-28b2-4cc4-ad31-c389bf923385/fb4d2c9f-01b2-41e8-929c-0059eb82167b/_apis/work/boardbadge/a4772e95-0e1e-42dd-9722-165f9321fc65)](https://dev.azure.com/irfan0032/f5c260a2-28b2-4cc4-ad31-c389bf923385/_boards/board/t/fb4d2c9f-01b2-41e8-929c-0059eb82167b/Microsoft.RequirementCategory)
 # Node exporter
 
 [![CircleCI](https://circleci.com/gh/prometheus/node_exporter/tree/master.svg?style=shield)][circleci]


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/irfan0032/f5c260a2-28b2-4cc4-ad31-c389bf923385/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.